### PR TITLE
Merge libs to the extent possible.  Where not possible (pragmas in cp…

### DIFF
--- a/Build/Interactivity.Win32.Cpp/Interactivity.Win32.Cpp.vcxproj
+++ b/Build/Interactivity.Win32.Cpp/Interactivity.Win32.Cpp.vcxproj
@@ -109,7 +109,11 @@
     </Link>
     <Lib>
       <AdditionalOptions>/ignore:4099</AdditionalOptions>
-    </Lib>
+      <AdditionalDependencies>libeay32.lib;ssleay32.lib;zlibstatic.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(ProjectDir)\..\..\External\Packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\lib\native\v140\windesktop\msvcstl\static\rt-dyn\$(Platform)\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">$(ProjectDir)\..\..\External\Packages\openssl.v140.windesktop.msvcstl.static.rt-dyn.x64.1.0.2.0\lib\native\v140\windesktop\msvcstl\static\rt-dyn\x64\release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='Win32'">$(ProjectDir)\..\..\External\Packages\openssl.v140.windesktop.msvcstl.static.rt-dyn.x86.1.0.2.0\lib\native\v140\windesktop\msvcstl\static\rt-dyn\x86\release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Lib>    
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
   </ItemDefinitionGroup>
@@ -126,6 +130,15 @@
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Target Name="CopyBoostLibs" AfterTargets="Build">
+    <PropertyGroup>
+      <BoostAddressModel Condition="'$(Platform)'=='Win32'">address-model-32</BoostAddressModel>
+      <BoostAddressModel Condition="'$(Platform)'=='x64'">address-model-64</BoostAddressModel>
+    </PropertyGroup>
+    <Copy SourceFiles="$(ProjectDir)..\..\External\Packages\boost_date_time-vc140.1.58.0-vs140rc\lib\native\$(BoostAddressModel)\lib\libboost_date_time-vc140-mt-1_58.lib" DestinationFolder="$(OutDir)"/>
+    <Copy SourceFiles="$(ProjectDir)..\..\External\Packages\boost_regex-vc140.1.58.0-vs140rc\lib\native\$(BoostAddressModel)\lib\libboost_regex-vc140-mt-1_58.lib" DestinationFolder="$(OutDir)"/>
+    <Copy SourceFiles="$(ProjectDir)..\..\External\Packages\boost_system-vc140.1.58.0-vs140rc\lib\native\$(BoostAddressModel)\lib\libboost_system-vc140-mt-1_58.lib" DestinationFolder="$(OutDir)"/>
+  </Target>
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>


### PR DESCRIPTION
…prest) copy the libs alongside build output.  This simplifies the link environment required to consume this SDK.