### PR TITLE
Make sure connecting task lives for the entire duration of the connec…

### DIFF
--- a/Source/Util/mixer_web_socket_connection.cpp
+++ b/Source/Util/mixer_web_socket_connection.cpp
@@ -83,13 +83,11 @@ web_socket_connection::ensure_connected()
             if (auto pThisWeak = thisWeakPtr.lock())
             {
                 // Trigger connection logic
-                pThisWeak->connect_async();
+                return pThisWeak->connect_async();
             }
         }
-        else
-        {
-            pplx::task_from_result();
-        }
+
+        return pplx::task_from_result();
     });
 }
 


### PR DESCRIPTION
…tion event, to avoid overlapping which seems to cause problems with some implementations.