### PR TITLE
Add Title ID and Service Config

### DIFF
--- a/samples/InteractiveXboxSample/Package.appxmanifest
+++ b/samples/InteractiveXboxSample/Package.appxmanifest
@@ -43,6 +43,9 @@
               <mx:GpuAvailability>variable</mx:GpuAvailability>
             </mx:XboxSystemResources>
           </mx:Extension>
+          <mx:Extension Category="xbox.live">
+            <mx:XboxLive TitleId="0A6D2730" PrimaryServiceConfigId="5deb0100-042c-41d9-9ec5-55580a6d2730"/>
+          </mx:Extension>
         </Extensions>
     </Application>
   </Applications>


### PR DESCRIPTION
In order to broadcast from an Xbox One, you need a Title ID and Service Configuration ID. This way anyone who runs the sample. It will "just work".