### PR TITLE
Refactor connection

### DIFF
--- a/Tests/Tests.cpp
+++ b/Tests/Tests.cpp
@@ -395,9 +395,10 @@ void handle_participants_changed(void* context, interactive_session session, int
 	Logger::WriteMessage(s.str().c_str());
 }
 
-void handle_error(void* context, interactive_session session, int errorCode, const char* errorMessage, size_t errorMessageLength)
+void handle_error_assert(void* context, interactive_session session, int errorCode, const char* errorMessage, size_t errorMessageLength)
 {
 	Logger::WriteMessage(("[ERROR] (" + std::to_string(errorCode) + ")" + errorMessage).c_str());
+	Assert::Fail(L"Error.");
 }
 
 void handle_unhandled_method(void* context, interactive_session session, const char* methodJson, size_t methodJsonLength)
@@ -537,6 +538,7 @@ public:
 		interactive_session session;
 		Logger::WriteMessage("Connecting...");
 		ASSERT_NOERR(interactive_open_session(&session));
+		ASSERT_NOERR(interactive_set_error_handler(session, handle_error_assert));
 		ASSERT_NOERR(interactive_connect(session, auth.c_str(), versionId.c_str(), shareCode.c_str(), true));
 
 		// Simulate 60 frames/sec for 1 seconds.
@@ -571,6 +573,7 @@ public:
 		interactive_session session;
 		Logger::WriteMessage("Connecting...");
 		ASSERT_NOERR(interactive_open_session(&session));
+		ASSERT_NOERR(interactive_set_error_handler(session, handle_error_assert));
 		ASSERT_NOERR(interactive_connect(session, auth.c_str(), versionId.c_str(), shareCode.c_str(), true));
 
 		// Simulate 60 frames/sec for 1 seconds.
@@ -603,10 +606,10 @@ public:
 
 		interactive_session session;
 		ASSERT_NOERR(interactive_open_session(&session));
-
+		ASSERT_NOERR(interactive_set_error_handler(session, handle_error_assert));
 		ASSERT_NOERR(interactive_set_input_handler(session, handle_input));
 		ASSERT_NOERR(interactive_set_state_changed_handler(session, handle_state_changed));
-		ASSERT_NOERR(interactive_set_error_handler(session, handle_error));
+		ASSERT_NOERR(interactive_set_error_handler(session, handle_error_assert));
 		ASSERT_NOERR(interactive_set_participants_changed_handler(session, handle_participants_changed));
 		ASSERT_NOERR(interactive_set_unhandled_method_handler(session, handle_unhandled_method));
 		ASSERT_NOERR(interactive_set_transaction_complete_handler(session, handle_transaction_complete));
@@ -646,6 +649,7 @@ public:
 
 		interactive_session session;
 		ASSERT_NOERR(interactive_open_session(&session));
+		ASSERT_NOERR(interactive_set_error_handler(session, handle_error_assert));
 		interactive_set_state_changed_handler(session, [](void* context, interactive_session session, interactive_state prevState, interactive_state newState)
 		{
 			Logger::WriteMessage(("Interactive state changed: " + std::to_string(prevState) + " -> " + std::to_string(newState)).c_str());
@@ -700,6 +704,7 @@ public:
 		interactive_session session;
 		Logger::WriteMessage("Connecting...");
 		ASSERT_NOERR(interactive_open_session(&session));
+		ASSERT_NOERR(interactive_set_error_handler(session, handle_error_assert));
 		ASSERT_NOERR(interactive_set_participants_changed_handler(session, handle_participants_changed));
 		ASSERT_NOERR(interactive_connect(session, auth.c_str(), versionId.c_str(), shareCode.c_str(), true));
 
@@ -803,6 +808,7 @@ public:
 		interactive_session session;
 		Logger::WriteMessage("Connecting...");
 		ASSERT_NOERR(interactive_open_session(&session));
+		ASSERT_NOERR(interactive_set_error_handler(session, handle_error_assert));
 		ASSERT_NOERR(interactive_connect(session, auth.c_str(), versionId.c_str(), shareCode.c_str(), true));
 		ASSERT_NOERR(interactive_set_participants_changed_handler(session, handle_participants_changed));
 		// Simulate 60 frames/sec for 1 second.
@@ -916,8 +922,6 @@ public:
 
 		Logger::WriteMessage("Disconnecting...");
 		interactive_close_session(session);
-
-		Assert::IsTrue(0 == err);
 	}
 };
 }

--- a/source/interactivity.h
+++ b/source/interactivity.h
@@ -77,20 +77,29 @@ extern "C" {
 	/// <summary>
 	/// An opaque handle to an interactive session.
 	/// </summary>
-	typedef void* interactive_session;
+	typedef void* interactive_session;	
+
+	/// <summary>
+	/// Open an <c>interactive_session</c>.
+	/// <param name="session">A pointer to an <c>interactive_session</c> that will be allocated internally.</param>
+	/// <remarks>
+	/// All calls to <c>interactive_open_session</c> must eventually be followed by a call to <c>interactive_close_session</c> to free the handle.
+	/// </remarks>
+	/// </summary>
+	int interactive_open_session(interactive_session* session);
 
 	/// <summary>
 	/// Open an interactive session. All calls to <c>interactive_open_session</c> must eventually be followed by a call to <c>interactive_close_session</c> to avoid a memory leak.
 	/// </summary>
+	/// <param name="session">An interactive session handle opened with <c>interactive_open_session</c>.</param>
 	/// <param name="auth">The authorization header that is passed to the service. This should either be a OAuth Bearer token or an XToken.</param>
 	/// <param name="versionId">The id of the interative project that should be started.</param>
 	/// <param name="shareCode">An optional parameter that is used when starting an interactive project that the user does not have implicit access to. This is usually required unless a project has been published.</param>
 	/// <param name="setReady">Specifies if the session should set the interactive ready state during connection. If false, this can be manually toggled later with <c>interactive_set_ready</c></param>
-	/// <param name="session">A handle to an interactive session. All calls to <c>interactive_open_session</c> must eventually be followed by a call to <c>interactive_close_session</c> to free the handle.</param>
 	/// <remarks>
 	/// This is a blocking function that waits on network IO, it is not recommended to call this from the UI thread.
 	/// </remarks>
-	int interactive_open_session(const char* auth, const char* versionId, const char* shareCode, bool setReady, interactive_session* session);
+	int interactive_connect(interactive_session session, const char* auth, const char* versionId, const char* shareCode, bool setReady);
 
 	/// <summary>
 	/// Set the ready state for specified session. No participants will be able to see interactive scenes or give input
@@ -597,7 +606,8 @@ extern "C" {
 		MIXER_ERROR_WS_CONNECT_FAILED,
 		MIXER_ERROR_WS_DISCONNECT_FAILED,
 		MIXER_ERROR_WS_READ_FAILED,
-		MIXER_ERROR_WS_SEND_FAILED
+		MIXER_ERROR_WS_SEND_FAILED,
+		MIXER_ERROR_NOT_CONNECTED
 
 	} mixer_result_code;
 	/** @} */

--- a/source/interactivity.h
+++ b/source/interactivity.h
@@ -608,7 +608,6 @@ extern "C" {
 		MIXER_ERROR_WS_READ_FAILED,
 		MIXER_ERROR_WS_SEND_FAILED,
 		MIXER_ERROR_NOT_CONNECTED
-
 	} mixer_result_code;
 	/** @} */
 

--- a/source/internal/interactive_control.cpp
+++ b/source/internal/interactive_control.cpp
@@ -126,6 +126,12 @@ int verify_get_property_args_and_get_control_value(interactive_session session, 
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	if (sessionInternal->shutdownRequested)
 	{
 		return MIXER_OK;
@@ -191,6 +197,11 @@ int interactive_control_get_property_count(interactive_session session, const ch
 
 	*count = 0;
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
 
 	auto controlItr = sessionInternal->controls.find(std::string(controlId));
 	if (controlItr == sessionInternal->controls.end())
@@ -210,6 +221,11 @@ int interactive_control_get_meta_property_count(interactive_session session, con
 
 	*count = 0;
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
 
 	auto controlItr = sessionInternal->controls.find(std::string(controlId));
 	if (controlItr == sessionInternal->controls.end())
@@ -230,6 +246,11 @@ int interactive_control_get_property_data(interactive_session session, const cha
 
 	*propType = interactive_property_type::interactive_unknown_t;
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
 
 	auto controlItr = sessionInternal->controls.find(std::string(controlId));
 	if (controlItr == sessionInternal->controls.end())
@@ -250,6 +271,11 @@ int interactive_control_get_meta_property_data(interactive_session session, cons
 
 	*propType = interactive_property_type::interactive_unknown_t;
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
 
 	auto controlItr = sessionInternal->controls.find(std::string(controlId));
 	if (controlItr == sessionInternal->controls.end())

--- a/source/internal/interactive_group.cpp
+++ b/source/internal/interactive_group.cpp
@@ -42,6 +42,11 @@ int interactive_get_groups(interactive_session session, on_group_enumerate onGro
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
 
 	// Lock the scene cache
 	std::shared_lock<std::shared_mutex> l(sessionInternal->scenesMutex);

--- a/source/internal/interactive_participant.cpp
+++ b/source/internal/interactive_participant.cpp
@@ -31,6 +31,12 @@ int interactive_get_participants(interactive_session session, on_participant_enu
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	for (auto& participantById : sessionInternal->participants)
 	{
 		interactive_participant participant;
@@ -72,6 +78,12 @@ int interactive_participant_get_user_id(interactive_session session, const char*
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	auto participantItr = sessionInternal->participants.find(std::string(participantId));
 	if (sessionInternal->participants.end() == participantItr)
 	{
@@ -91,6 +103,12 @@ int interactive_participant_get_user_name(interactive_session session, const cha
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	auto participantItr = sessionInternal->participants.find(std::string(participantId));
 	if (sessionInternal->participants.end() == participantItr)
 	{
@@ -120,6 +138,12 @@ int interactive_participant_get_level(interactive_session session, const char* p
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	auto participantItr = sessionInternal->participants.find(std::string(participantId));
 	if (sessionInternal->participants.end() == participantItr)
 	{
@@ -139,6 +163,12 @@ int interactive_participant_get_last_input_at(interactive_session session, const
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	auto participantItr = sessionInternal->participants.find(std::string(participantId));
 	if (sessionInternal->participants.end() == participantItr)
 	{
@@ -158,6 +188,12 @@ int interactive_participant_get_connected_at(interactive_session session, const 
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	auto participantItr = sessionInternal->participants.find(std::string(participantId));
 	if (sessionInternal->participants.end() == participantItr)
 	{
@@ -177,6 +213,12 @@ int interactive_participant_is_disabled(interactive_session session, const char*
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	auto participantItr = sessionInternal->participants.find(std::string(participantId));
 	if (sessionInternal->participants.end() == participantItr)
 	{
@@ -196,6 +238,12 @@ int interactive_participant_get_group(interactive_session session, const char* p
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	auto participantItr = sessionInternal->participants.find(std::string(participantId));
 	if (sessionInternal->participants.end() == participantItr)
 	{

--- a/source/internal/interactive_scene.cpp
+++ b/source/internal/interactive_scene.cpp
@@ -55,6 +55,12 @@ int interactive_get_scenes(interactive_session session, on_scene_enumerate onSce
 	}
 
 	interactive_session_internal* sessionInternal = reinterpret_cast<interactive_session_internal*>(session);
+	// Validate connection state.
+	if (interactive_disconnected == sessionInternal->state)
+	{
+		return MIXER_ERROR_NOT_CONNECTED;
+	}
+
 	// Lock the scenes while they are being enumerated.
 	std::shared_lock<std::shared_mutex> l(sessionInternal->scenesMutex);
 	for (auto sceneItr = sessionInternal->scenes.begin(); sessionInternal->scenes.end() != sceneItr; ++sceneItr)

--- a/source/internal/interactive_session.cpp
+++ b/source/internal/interactive_session.cpp
@@ -924,8 +924,14 @@ void interactive_close_session(interactive_session session)
 		}
 
 		// Wait for both threads to terminate.
-		sessionInternal->incomingThread.join();
-		sessionInternal->outgoingThread.join();
+		if (sessionInternal->incomingThread.joinable())
+		{
+			sessionInternal->incomingThread.join();
+		}
+		if (sessionInternal->outgoingThread.joinable())
+		{
+			sessionInternal->outgoingThread.join();
+		}
 
 		// Clean up the session memory.
 		delete sessionInternal;


### PR DESCRIPTION
This CL splits the interactive_open_session into two separate functions, interactive_open_session and interactive_connect. This allows handlers, most importantly _error_ handlers, to be registered before they might be called.

Fixes #73 #75 #77 #78 