### PR TITLE
fix: C++17 compliance  Change the obsolete auto_ptr into the equivalent unique_ptr  closes #94

### DIFF
--- a/source/internal/interactive_session.cpp
+++ b/source/internal/interactive_session.cpp
@@ -493,7 +493,7 @@ int interactive_open_session(interactive_session* sessionPtr)
 		return MIXER_ERROR_INVALID_POINTER;
 	}
 
-	std::auto_ptr<interactive_session_internal> session(new interactive_session_internal());
+	auto session = std::make_unique< interactive_session_internal>();
 
 	// Register method handlers
 	register_method_handlers(*session);


### PR DESCRIPTION
fix: C++17 compliance

Change the obsolete auto_ptr into the equivalent unique_ptr

closes 94