### PR TITLE
chore(docs): redirect to html folder root

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1;url=html/index.html">
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        If you are not redirected automatically, 
+        follow the <a href="html/index.html">link to the documentation</a>
+    </body>
+</html>


### PR DESCRIPTION
Github requires the docs folder to have an index.html.

Doxygen creates html in docs/html.

I couldn't figure out how to make doxygen not generate the html within docs/html so this creates a file which will automatically redirect the user into the correct place.