### PR TITLE
Correct argument type of string property setter

### DIFF
--- a/source/interactivity.h
+++ b/source/interactivity.h
@@ -325,7 +325,7 @@ extern "C" {
 	/// <summary>
 	/// Set a <c>char*</c> property value by name.
 	/// </summary>
-	int interactive_control_set_property_string(interactive_session session, const char* controlId, const char* key, char* property);
+	int interactive_control_set_property_string(interactive_session session, const char* controlId, const char* key, const char* property);
 
 	/// <summary>
 	/// Get an <c>int</c> meta property value by name.


### PR DESCRIPTION
Signature of function interactive_control_set_property_string in interactivity.h differs from one in source file. Therefore using this function in client code leads to link error.

This corrects the type of argument property from char* to const char*.