### PR TITLE
fix(http_client): Occasional response corruption

### DIFF
--- a/source/internal/win_http_client.cpp
+++ b/source/internal/win_http_client.cpp
@@ -157,8 +157,9 @@ int win_http_client::make_request(const std::string& uri, const std::string& ver
 	char buffer[1024];
 	memset(buffer, 0, ARRAYSIZE(buffer));
 	DWORD bytesRead = 0;
-	while (winHttpApi.win_http_read_data(request.get(), buffer, ARRAYSIZE(buffer), &bytesRead) && bytesRead)
+	while (winHttpApi.win_http_read_data(request.get(), buffer, ARRAYSIZE(buffer) - 1, &bytesRead) && bytesRead)
 	{
+		buffer[bytesRead] = '\0';
 		responseStream << buffer;
 		bytesRead = 0;
 		memset(buffer, 0, ARRAYSIZE(buffer));


### PR DESCRIPTION
Due to a non null terminated buffer being used in string stream. It corrupts the response and then can't be parsed into a valid json object.

Difficult to reproduce. I was only able to reproduce it in one specific project with one specific mixer user (testing other users and other projects worked fine). Not entirely sure why it happens so rarely, but it was reproducible on my end and this fixes it.